### PR TITLE
refactor: improve metro configuration and explicit param names

### DIFF
--- a/src/tools/android.ts
+++ b/src/tools/android.ts
@@ -1,4 +1,5 @@
 import { tool } from 'ai'
+import dedent from 'dedent'
 import { z } from 'zod'
 
 import {
@@ -13,15 +14,23 @@ import { adb, getAdbPath, getEmulatorName } from './vendor-rncli'
 
 export const androidTools = {
   getAdbPath: tool({
-    description: 'Get path to ADB executable',
+    description: 'Returns path to ADB executable',
     parameters: z.object({}),
     execute: async () => {
       return getAdbPath()
     },
   }),
 
-  listAndroidDevices: tool({
-    description: 'List available Android devices and emulators',
+  getAndroidDevices: tool({
+    description: dedent`
+      Gets available Android devices and emulators.
+
+      Returns an array of devices:
+        - "id" - device ID
+        - "name" - device name
+        - "type" - device type ("device" or "emulator")
+        - "booted" - whether the device is booted
+    `,
     parameters: z.object({
       adbPath: z.string(),
     }),
@@ -50,12 +59,12 @@ export const androidTools = {
   }),
 
   bootAndroidEmulator: tool({
-    description: 'Boot Android emulator',
+    description: 'Boots a given Android emulator',
     parameters: z.object({
       adbPath: z.string(),
-      emulatorName: z.string(),
+      androidDevice_name: z.string(),
     }),
-    execute: async ({ adbPath, emulatorName }) => {
+    execute: async ({ adbPath, androidDevice_name: emulatorName }) => {
       await tryLaunchEmulator(adbPath, emulatorName)
     },
   }),
@@ -63,13 +72,18 @@ export const androidTools = {
   buildAndroidApp: tool({
     description: 'Builds Android application and install it on a given device',
     parameters: z.object({
-      deviceId: z.string(),
+      androidDevice_id: z.string(),
       metroPort: z.number(),
-      sourceDir: z.string(),
-      appName: z.string(),
+      reactNativeConfig_android_sourceDir: z.string(),
+      reactNativeConfig_android_appName: z.string(),
       mode: z.enum(['debug', 'release']),
     }),
-    execute: async ({ mode, appName, sourceDir, metroPort }) => {
+    execute: async ({
+      mode,
+      reactNativeConfig_android_appName: appName,
+      reactNativeConfig_android_sourceDir: sourceDir,
+      metroPort,
+    }) => {
       // tbd: taks selection
       // tbd: user selection
       // tbd: flavor selection
@@ -93,15 +107,21 @@ export const androidTools = {
   }),
 
   launchAndroidAppOnDevice: tool({
-    description: 'Launch Android application on a given device',
+    description: 'Launches a given Android application on a specified device',
     parameters: z.object({
-      deviceId: z.string(),
+      androidDevice_id: z.string(),
       adbPath: z.string(),
-      packageName: z.string(),
-      mainActivity: z.string(),
-      applicationId: z.string(),
+      reactNativeConfig_android_packageName: z.string(),
+      reactNativeConfig_android_mainActivity: z.string(),
+      reactNativeConfig_android_applicationId: z.string(),
     }),
-    execute: async ({ deviceId, adbPath, packageName, mainActivity, applicationId }) => {
+    execute: async ({
+      androidDevice_id: deviceId,
+      adbPath,
+      reactNativeConfig_android_packageName: packageName,
+      reactNativeConfig_android_mainActivity: mainActivity,
+      reactNativeConfig_android_applicationId: applicationId,
+    }) => {
       try {
         // @ts-ignore
         tryLaunchAppOnDevice(deviceId, { packageName, mainActivity, applicationId }, adbPath, {

--- a/src/tools/apple.ts
+++ b/src/tools/apple.ts
@@ -15,8 +15,6 @@ import {
 const platforms = ['ios', 'tvos', 'visionos'] as const
 
 export const iosTools = {
-  // Explicit naming helps AI to understand the purpose of the tool
-
   listAppleSimulators: tool({
     description: 'List available simulators',
     parameters: z.object({

--- a/src/tools/react-native.ts
+++ b/src/tools/react-native.ts
@@ -10,23 +10,27 @@ import { z } from 'zod'
 import { loadReactNativeConfig } from './vendor-rncli'
 
 export const reactNativeTools = {
-  startMetro: tool({
-    description: 'Start Metro bundler',
+  startMetroDevServer: tool({
+    description: dedent`
+      Starts Metro development server on a given port or a different available port.
+      Returns port Metro server started on.
+    `,
     parameters: z.object({
       port: z.number().default(8081),
+      reactNativeConfig_root: z.string(),
+      reactNativeConfig_reactNativePath: z.string(),
     }),
-    execute: async ({ port }) => {
+    execute: async ({
+      port,
+      reactNativeConfig_root: root,
+      reactNativeConfig_reactNativePath: reactNativePath,
+    }) => {
       try {
-        const config = await loadReactNativeConfig()
-        const { port: newPort } = await findDevServerPort(port, config.root)
-        startServerInNewWindow(
-          newPort,
-          config.root,
-          config.reactNativePath,
-          getDefaultUserTerminal()
-        )
+        const { port: newPort } = await findDevServerPort(port, root)
+        startServerInNewWindow(newPort, root, reactNativePath, getDefaultUserTerminal())
         return {
           success: true,
+          port: newPort,
         }
       } catch (error) {
         return {
@@ -38,30 +42,46 @@ export const reactNativeTools = {
 
   getReactNativeConfig: tool({
     description: dedent`
-      Get React Native configuration. Returns available platforms, Android and iOS project configuration.
+      Get React Native configuration. 
+      
+      Returns:
+        - "root" - root directory of the project
+        - "path" - path to React Native CLI installation
+        - "version" - React Native version
+        - "platforms" - available platforms
+        - "project" - project configuration per platform
 
-      Android project configuration includes:
-        - sourceDir
-        - appName
-        - packageName
-        - applicationId
-        - mainActivity
-        - assets
+      Apple project configuration:
+        - "sourceDir" - iOS source directory
+        - "xcodeProject" - Xcode project configuration
+          - "name" - iOS project name
+          - "path" - path to the Xcode project
+          - "isWorkspace" - whether the project is a workspace
+        - "assets" - iOS assets
 
-      iOS project configuration includes:
-        - sourceDir
-        - xcodeProject
-          - name
-          - path
-          - isWorkspace
-        - assets
+      Android project configuration:
+        - "sourceDir" - Android source directory
+        - "appName" - Android app name
+        - "packageName" - Android package name
+        - "applicationId" - Android application ID
+        - "mainActivity" - Android main activity
+        - "assets" - Android assets
     `,
     parameters: z.object({}),
     execute: async () => {
-      const config = await loadReactNativeConfig()
+      const {
+        root,
+        reactNativePath: path,
+        reactNativeVersion: version,
+        project,
+        platforms,
+      } = await loadReactNativeConfig()
       return {
-        ...config.project,
-        platforms: Object.keys(config.project),
+        root,
+        path,
+        version,
+        project,
+        platforms,
       }
     },
   }),


### PR DESCRIPTION
Proposed pattern is:
`getXXX`

and then, to refer to its return type later in another tool
`xxx_key`

to hint that you can get that key by calling a given too.

Also, since there's no return type information, I added explicit description to a few tools to help LLM understand what can it get in return.