### PR TITLE
feat(android): use device id explicitly all the time

### DIFF
--- a/src/tools/android.ts
+++ b/src/tools/android.ts
@@ -59,13 +59,23 @@ export const androidTools = {
   }),
 
   bootAndroidEmulator: tool({
-    description: 'Boots a given Android emulator',
+    description: 'Boots a given Android emulator and returns its ID',
     parameters: z.object({
       adbPath: z.string(),
       androidDevice_name: z.string(),
     }),
     execute: async ({ adbPath, androidDevice_name: emulatorName }) => {
-      await tryLaunchEmulator(adbPath, emulatorName)
+      try {
+        await tryLaunchEmulator(adbPath, emulatorName)
+        return {
+          success: true,
+          action: `Device booted. Re-run "getAndroidDevices" to verify ${emulatorName} is in the list, with "booted" set to true.`,
+        }
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : 'Failed to boot emulator',
+        }
+      }
     },
   }),
 


### PR DESCRIPTION
Previously, it would pass undefined device id (which is default behavior in the CLI after booting a simulator), as ADB will try to launch it on it, unless there's more devices booted.

However, I think passing an explicit deviceID is more future proof, and was always required by the tool anyway.