### PR TITLE
feat: reset context on each session

### DIFF
--- a/packages/cali/src/cli.ts
+++ b/packages/cali/src/cli.ts
@@ -49,35 +49,38 @@ console.log(
 )
 
 const OPENAI_API_KEY =
-  process.env.OPENAI_API_KEY ||
+  process.env.OPENdAI_API_KEY ||
   (await (async () => {
-    let apiKey: string | symbol
-    do {
-      apiKey = await text({
-        message: dedent`
-          ${chalk.bold('Please provide your OpenAI API key.')}
+    const apiKey = await text({
+      message: dedent`
+        ${chalk.bold('Please provide your OpenAI API key.')}
 
-          To skip this message, set ${chalk.bold('OPENAI_API_KEY')} env variable, and run again. 
-          
-          You can do it in three ways:
-          - by creating an ${chalk.bold('.env.local')} file (make sure to ${chalk.bold('.gitignore')} it)
-            ${chalk.gray(`\`\`\`
-              OPENAI_API_KEY=<your-key>
-              \`\`\`
-            `)}
-          - by passing it inline:
-            ${chalk.gray(`\`\`\`
-              OPENAI_API_KEY=<your-key> npx cali
-              \`\`\`
-            `)}
-          - by setting it as an env variable in your shell (e.g. in ~/.zshrc or ~/.bashrc):
-            ${chalk.gray(`\`\`\`
-              export OPENAI_API_KEY=<your-key>
-              \`\`\`
-            `)},
-          `,
-      })
-    } while (typeof apiKey !== 'string')
+        To skip this message, set ${chalk.bold('OPENAI_API_KEY')} env variable, and run again. 
+        
+        You can do it in three ways:
+        - by creating an ${chalk.bold('.env.local')} file (make sure to ${chalk.bold('.gitignore')} it)
+          ${chalk.gray(`\`\`\`
+            OPENAI_API_KEY=<your-key>
+            \`\`\`
+          `)}
+        - by passing it inline:
+          ${chalk.gray(`\`\`\`
+            OPENAI_API_KEY=<your-key> npx cali
+            \`\`\`
+          `)}
+        - by setting it as an env variable in your shell (e.g. in ~/.zshrc or ~/.bashrc):
+          ${chalk.gray(`\`\`\`
+            export OPENAI_API_KEY=<your-key>
+            \`\`\`
+          `)},
+        `,
+      validate: (value) => (value.length > 0 ? undefined : 'Please provide a valid answer.'),
+    })
+
+    if (typeof apiKey === 'symbol') {
+      outro(chalk.gray('Bye!'))
+      process.exit(0)
+    }
 
     const save = await confirm({
       message: 'Do you want to save it for future runs in `.env.local`?',

--- a/packages/cali/src/cli.ts
+++ b/packages/cali/src/cli.ts
@@ -5,7 +5,7 @@ import 'dotenv/config'
 import { execSync } from 'node:child_process'
 
 import { createOpenAI } from '@ai-sdk/openai'
-import { confirm, log, outro, select, spinner, text } from '@clack/prompts'
+import { confirm, outro, select, spinner, text } from '@clack/prompts'
 import { CoreMessage, generateText } from 'ai'
 import * as tools from 'cali-tools'
 import chalk from 'chalk'
@@ -19,10 +19,15 @@ const MessageSchema = z.union([
   z.object({ type: z.literal('select'), content: z.string(), options: z.array(z.string()) }),
   z.object({ type: z.literal('question'), content: z.string() }),
   z.object({ type: z.literal('confirmation'), content: z.string() }),
-  z.object({ type: z.literal('end'), content: z.string() }),
+  z.object({ type: z.literal('end') }),
 ])
 
 console.clear()
+
+// tbd: better error handling
+process.on('uncaughtException', (error) => {
+  console.error(chalk.red(error.message))
+})
 
 console.log(
   retro(`
@@ -42,8 +47,6 @@ console.log(
     Powered by: ${chalk.bold('Vercel AI SDK')} & ${chalk.bold('React Native CLI')}
   `)
 )
-
-console.log()
 
 const OPENAI_API_KEY =
   process.env.OPENAI_API_KEY ||
@@ -94,26 +97,31 @@ const openai = createOpenAI({
   apiKey: OPENAI_API_KEY,
 })
 
-const question = await text({
-  message: 'What do you want to do today?',
-  placeholder: 'e.g. "Build the app" or "See available simulators"',
-})
+async function startSession(): Promise<CoreMessage[]> {
+  const question = await text({
+    message: 'What do you want to do today?',
+    placeholder: 'e.g. "Build the app" or "See available simulators"',
+    validate: (value) => (value.length > 0 ? undefined : 'Please provide a valid answer.'),
+  })
 
-if (typeof question === 'symbol') {
-  outro(chalk.gray('Bye!'))
-  process.exit(0)
+  if (typeof question === 'symbol') {
+    outro(chalk.gray('Bye!'))
+    process.exit(0)
+  }
+
+  return [
+    {
+      role: 'system',
+      content: 'What do you want to do today?',
+    },
+    {
+      role: 'user',
+      content: question,
+    },
+  ]
 }
 
-const messages: CoreMessage[] = [
-  {
-    role: 'system',
-    content: 'What do you want to do today?',
-  },
-  {
-    role: 'user',
-    content: question,
-  },
-]
+let messages = await startSession()
 
 const s = spinner()
 
@@ -195,20 +203,21 @@ while (true) {
           options: data.options.map((option) => ({ value: option, label: option })),
         })
       case 'question':
-        return text({ message: data.content })
+        return text({
+          message: data.content,
+          validate: (value) => (value.length > 0 ? undefined : 'Please provide a valid answer.'),
+        })
       case 'confirmation': {
         return confirm({ message: data.content }).then((answer) => {
           return answer ? 'yes' : 'no'
         })
       }
-      case 'end':
-        log.step(data.content)
     }
   })()
 
   if (typeof answer !== 'string') {
-    outro(chalk.gray('Bye!'))
-    break
+    messages = await startSession()
+    continue
   }
 
   messages.push({

--- a/packages/cali/src/cli.ts
+++ b/packages/cali/src/cli.ts
@@ -24,9 +24,9 @@ const MessageSchema = z.union([
 
 console.clear()
 
-// tbd: better error handling
 process.on('uncaughtException', (error) => {
   console.error(chalk.red(error.message))
+  console.log(chalk.gray(error.stack))
 })
 
 console.log(
@@ -49,7 +49,7 @@ console.log(
 )
 
 const OPENAI_API_KEY =
-  process.env.OPENdAI_API_KEY ||
+  process.env.OPENAI_API_KEY ||
   (await (async () => {
     const apiKey = await text({
       message: dedent`

--- a/packages/cali/src/prompt.ts
+++ b/packages/cali/src/prompt.ts
@@ -19,7 +19,6 @@ export const reactNativePrompt = dedent`
     - If you need more information, ask a follow-up question.
     - Never build or run for multiple platforms simultaneously.
     - If user selects "Debug" mode, always start Metro bundler using "startMetro" tool.
-    - Never end session, unless user confirms they do not want to continue.
 
   ERROR HANDLING:
     - If a tool call returns an error, you must explain the error to the user and ask user if they want to try again:
@@ -43,7 +42,7 @@ export const reactNativePrompt = dedent`
 
       - If user confirms, you must re-run the same tool.
       - Never ask user to perform the action manually. Instead, ask user to fix the error, so you can run the tool again.
-      - If single tool fails more than 3 times, proceed with NEXT TASK.
+      - If single tool fails more than 3 times, you must end the session.
 
   RESPONSE FORMAT:
     - Your response must be a valid JSON object.
@@ -67,16 +66,10 @@ export const reactNativePrompt = dedent`
         "type": "confirmation",
         "content": "<question>"
       }
-    - When you finish processing user task, you must ask user a confirmation if they want to continue with another task:
-      {
-        "type": "confirmation",
-        "content": "<question>"
-      }
-    - If user does not want to continue, you must return "end" type.
+    - When you finish processing user task, you must answer with:
       {
         "type": "end",
-        "content": "<result>"
-      } 
+      }
   
   EXAMPLES:
     <example>


### PR DESCRIPTION
fix: crash on empty message
fix: unable to exit process while asked for token

---

Important changes in this PR:

- Validate input from the user and warn on empty message. This would crash today.

- **Change behavior of LLM to end the session each time it is done with the task.** 
Today, the LLM would either ask a question to "continue with something else" or decide to terminate the process. Now, it must "finish session" each time it is done with a given task, which does not finish the process, but restarts the context. This is easier and gives us more control over what's going on.

- Fix unable to exit process while asked for Chat GPT token. 

- Print stack trace and error message when unhandled exception happens